### PR TITLE
Ensure Brew tap URL matches release path

### DIFF
--- a/Formula/baselime.rb
+++ b/Formula/baselime.rb
@@ -1,7 +1,7 @@
 class Baselime < Formula
   desc "Observability as code for serverless"
   homepage "https://github.com/baselime/cli"
-  url "https://github.com/baselime/cli/releases/download/v0.0.5/baselime-darwin-x64-v0.0.6.tar.gz"
+  url "https://github.com/baselime/cli/releases/download/v0.0.6/baselime-darwin-x64-v0.0.6.tar.gz"
   sha256 "0e8b3c79f38d2156c0f732e95a02e3ca5dbb981527bedf183a135ff2f342f0c6"
   license "MIT"
 


### PR DESCRIPTION
This had errored for me when doing an upgrade